### PR TITLE
#33 BNN Mission and Advertisements

### DIFF
--- a/calls/all_calls.xml
+++ b/calls/all_calls.xml
@@ -2,6 +2,7 @@
 <calls>
     <!-- COMMON calls -->
 	<call file="artillery1.call" />
+	<call file="bombing_run.call" />
 	<call file="buggy.call" />
 	<call file="bnn_advert.call" />
 	<call file="bnn_mission.call" />

--- a/calls/bombing_run.call
+++ b/calls/bombing_run.call
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<call name="Bombing Run" key="bombing_run.call" notify_metagame="1"
+  radio_view_text="Hell in a handbasket"
+  initiation_comment1="Line em up!"
+  acknowledge_comment="Bomber disptached..."
+  acknowledge_time="3.0"
+  launch_comment="Incoming!!">
+  <round launch_time="5.0"
+    spawn_time="8.0">
+  </round>
+  <round launch_time="7.0"
+    spawn_time="10.0">
+  </round>
+  <hud_icon filename="hud_flare_blue.png" />
+  <capacity value="0" source="rank" source_value="0.0" />
+  <capacity value="100" source="rank" source_value="0.4" />
+  <inventory encumbrance="0.0" price="250.0" />
+</call>

--- a/languages/en/default_shared.character
+++ b/languages/en/default_shared.character
@@ -5,7 +5,7 @@
 
 	<!-- BEGIN secession comment keys -->	
 
-  <!-- BEGIN BNN announcements -->
+  	<!-- BEGIN BNN announcements -->
 	<comment key="BNN mission" text="%company_name reports unwanted %activity near %location. Hostile: %rule_engage. Payment: %reward_type, %reward_amount." />
 	<comment key="BNN mission" text="RECON of %location requested by %company_name. Hostiles: %rule_engage. Looting: %rule_loot. Payment: %reward_type, %reward_amount" />
 	<comment key="BNN mission" text="COURIER service requested for %company_name. Pick up: %location_pickup. Drop off: %location_drop. Payment: %reward_type, %reward_amount" />

--- a/languages/en/default_shared.character
+++ b/languages/en/default_shared.character
@@ -6,7 +6,7 @@
 	<!-- BEGIN secession comment keys -->	
 
   	<!-- BEGIN BNN announcements -->
-	<comment key="BNN mission" text="%company_name reports unwanted %activity near %location. Hostile: %rule_engage. Payment: %reward_type, %reward_amount." />
+	<comment key="BNN mission" text="%company_name reports unwanted %activity near %vicinity. Hostile: %rule_engage. Payment: %reward_type, %reward_amount." />
 	<comment key="BNN mission" text="RECON of %location requested by %company_name. Hostiles: %rule_engage. Looting: %rule_loot. Payment: %reward_type, %reward_amount" />
 	<comment key="BNN mission" text="COURIER service requested for %company_name. Pick up: %location_pickup. Drop off: %location_drop. Payment: %reward_type, %reward_amount" />
 	<comment key="BNN mission" text="Anonymous DELETION request. Target: %character_name. Location: %vicinity %location. Payment: %reward_amount cash" />

--- a/scripts/gamemodes/invasion/gamemode_invasion.as
+++ b/scripts/gamemodes/invasion/gamemode_invasion.as
@@ -17,6 +17,7 @@
 // generic trackers
 #include "basic_command_handler.as"
 #include "call_handler.as"
+#include "bnn.as"
 #include "autosaver.as"
 #include "prison_break_objective.as"
 #include "unlock_manager.as"
@@ -274,7 +275,9 @@ class GameModeInvasion : GameMode, UnlockRemoveListener, UnlockListener {
 
 		addTracker(BasicCommandHandler(this));
 
-		addTracker(CallHandler(this));
+		addTracker(CallHandler(this)); // Secession: CallHandler Class and Methods
+
+		addTracker(BNN(this)); // Secession: Broadcast News Network Class and Methods
 	}
 
 	// --------------------------------------------

--- a/scripts/internal/helpers.as
+++ b/scripts/internal/helpers.as
@@ -435,6 +435,19 @@ void merge(array<const XmlElement@>@ a1, const array<const XmlElement@>@ a2) {
 	}
 }
 
+// BEGIN SECESSION HELPERS
+// BC Hot Potato Position Tracker
+string hpPosition;
+void setHotPotPosi(string pos) {
+	hpPosition = pos;
+	_log("Hot Potato now at: " + hpPosition, 1);
+}
+string getHotPotPosi() {
+	return hpPosition;
+}
+
+// END SECESSION HELPERS
+// --------------------------------------------
 
 /*
 // --------------------------------------------

--- a/scripts/start_campaign.as
+++ b/scripts/start_campaign.as
@@ -1,5 +1,4 @@
 #include "path://media/packages/secession/scripts"
-
 #include "my_gamemode.as"
 
 // --------------------------------------------

--- a/scripts/trackers/bnn.as
+++ b/scripts/trackers/bnn.as
@@ -10,14 +10,26 @@
 class BNN : Tracker {
 	protected GameMode@ m_metagame;
 
-    protected float MISSION_TIMER_MAX = 80.00; //180
-    protected float MISSION_TIMER_MIN = 45.00; //90
-	protected float m_timer; // mission random timer
-    protected float ADVERT_TIMER_MAX = 40.00; //240
-    protected float ADVERT_TIMER_MIN = 20.00; //120
-	protected float a_timer; // advert random timer
+    protected float MISSION_TIMER_MAX = 36.00; //180
+    protected float MISSION_TIMER_MIN = 18.00; //90
+	protected float miTimer; // mission random timer
+    protected float ADVERT_TIMER_MAX = 240.00;
+    protected float ADVERT_TIMER_MIN = 120.00;
+	protected float adTimer; // advert random timer
 	protected array<string> activeTimers = {"mission", "advert"}; // stores the names of active timers
 	protected dictionary bnn_dict;
+
+	// one of each of the following arrays' strings is chosen at random to populate BNN missions
+	protected array<string> actArr = {"The thing", "The stuff", "fun fun fun"};
+	protected array<string> charArr = {"Dr. Evil", "Seymour Butts", "Harry Potter"};
+	protected array<string> compArr = {"Uranus Proctology", "Udonis Noodles", "Pompeii Insurance", "ZEROGEE Sick Bags"};
+	// location_pickup, location_drop, and location will be anywhere in a 1024 square area.
+	// vicinity will be the name of the map area nearest to location
+	// reward_amount will be a uint figure between 50 and 5000 - needs serious logic rules to set a relevant value to the mission and requestor
+	protected array<string> rTypeArr = {"XP", "RP", "Weapon", "Armour", "Vehicle"};
+	protected array<string> rEngageArr = {"Avoid", "Eliminate", "Rout", "Distract"};
+	protected array<string> rLootArr = {"Allowed", "Discouraged", "Prohibited"};
+
 	// ----------------------------------------------------
 	BNN(GameMode@ metagame) {
 		@m_metagame = @metagame;
@@ -28,16 +40,16 @@ class BNN : Tracker {
 
 	protected void restartTimer(string timer) {
 		if (timer == "mission") {
-			m_timer = rand(MISSION_TIMER_MIN, MISSION_TIMER_MAX);
-			_log("BNN mission timer restarting with count: " + m_timer ,1);
+			miTimer = rand(MISSION_TIMER_MIN, MISSION_TIMER_MAX);
+			_log("BNN mission timer restarting with count: " + miTimer ,1);
 		} else if (timer == "advert") {
-			a_timer = rand(ADVERT_TIMER_MIN, ADVERT_TIMER_MAX);
-			_log("BNN advert timer restarting with count: " + a_timer, 1);
+			adTimer = rand(ADVERT_TIMER_MIN, ADVERT_TIMER_MAX);
+			_log("BNN advert timer restarting with count: " + adTimer, 1);
 		}
 	}
 
 	protected dictionary makeBNNDict(string type) {
-		// this method creates randomly-populated dictionaries for BNN Missions (0) and Adverts (1)
+		// this method creates randomly-populated dictionaries for BNN Missions and Advertisments
 		if (type == "mission") {
 			dictionary bnn_dict = {
 				{"%activity", "the thing"},
@@ -62,7 +74,6 @@ class BNN : Tracker {
 	}
 
 	protected void newBNNAnnouncement(string type, dictionary a) {
-		_log("making a thing now!", 1);
 		notify(m_metagame, "BNN " + type, a);
 	}
 
@@ -88,28 +99,28 @@ class BNN : Tracker {
 
 	// --------------------------------------------
 	void update(float time) {
-		m_timer -= time;
-		a_timer -= time;
-		if (m_timer <= 0.0) {
+		miTimer -= time;
+		adTimer -= time;
+		if (miTimer <= 0.0) {
 			_log("mission timer expired. BNN announcement incoming", 1);
 			//dictionary miDict = makeBNNDict("mission");
 			dictionary miDict = {
-				{"%activity", "the thing"},
-				{"%character_name", "char name"},
-				{"%company_name", "Bob Pizza"}, 
-				{"%location_pickup", "round the corner"},
-				{"%location_drop", "rah bish binnie"},
-				{"%location", "secret loc"},
-				{"%vicinity", "k-mart carpark"},
-				{"%reward_amount", "heaps!"},
-				{"%reward_type", "Pants"}, 
-				{"%rule_engage", "Kill em all!"},
-				{"%rule_loot", "don't touch!"}
+				{"%activity", actArr[rand(0, actArr.size() -1)] },
+				{"%character_name", charArr[rand(0, charArr.size() -1)] },
+				{"%company_name", compArr[rand(0, compArr.size() -1)] }, 
+				{"%location_pickup", rand(0, 1024) + ", " + rand(0,1024) },
+				{"%location_drop", rand(0, 1024) + ", " + rand(0,1024) },
+				{"%location", rand(0, 1024) + ", " + rand(0,1024) },
+				{"%vicinity", "map_area name" },
+				{"%reward_amount", rand(50, 5000) },
+				{"%reward_type", rTypeArr[rand(0, rTypeArr.size() -1)] }, 
+				{"%rule_engage", rEngageArr[rand(0, rEngageArr.size() -1)] },
+				{"%rule_loot", rLootArr[rand(0, rLootArr.size() -1)] }
 			};
 			newBNNAnnouncement("mission", miDict);
 			restartTimer("mission");
 		} 
-		if (a_timer <= 0.0) {
+		if (adTimer <= 0.0) {
 			_log("advert timer expired. BNN announcement incoming", 1);
 			dictionary adDict = makeBNNDict("advert");
 			newBNNAnnouncement("advert", adDict);

--- a/scripts/trackers/bnn.as
+++ b/scripts/trackers/bnn.as
@@ -1,0 +1,135 @@
+// internal
+#include "tracker.as"
+#include "gamemode.as"
+#include "log.as"
+
+// --------------------------------------------
+
+
+// --------------------------------------------
+class BNN : Tracker {
+	protected GameMode@ m_metagame;
+
+    protected float MISSION_TIMER_MAX = 80.00; //180
+    protected float MISSION_TIMER_MIN = 45.00; //90
+	protected float m_timer; // mission random timer
+    protected float ADVERT_TIMER_MAX = 40.00; //240
+    protected float ADVERT_TIMER_MIN = 20.00; //120
+	protected float a_timer; // advert random timer
+	protected array<string> activeTimers = {"mission", "advert"}; // stores the names of active timers
+	protected dictionary bnn_dict;
+	// ----------------------------------------------------
+	BNN(GameMode@ metagame) {
+		@m_metagame = @metagame;
+
+		restartTimer("mission");
+		restartTimer("advert");
+	}
+
+	protected void restartTimer(string timer) {
+		if (timer == "mission") {
+			m_timer = rand(MISSION_TIMER_MIN, MISSION_TIMER_MAX);
+			_log("BNN mission timer restarting with count: " + m_timer ,1);
+		} else if (timer == "advert") {
+			a_timer = rand(ADVERT_TIMER_MIN, ADVERT_TIMER_MAX);
+			_log("BNN advert timer restarting with count: " + a_timer, 1);
+		}
+	}
+
+	protected dictionary makeBNNDict(string type) {
+		// this method creates randomly-populated dictionaries for BNN Missions (0) and Adverts (1)
+		if (type == "mission") {
+			dictionary bnn_dict = {
+				{"%activity", "the thing"},
+				{"%character_name", "char name"},
+				{"%company_name", "Bob Pizza"}, 
+				{"%location_pickup", "round the corner"},
+				{"%location_drop", "rah bish binnie"},
+				{"%location", "secret loc"},
+				{"%vicinity", "k-mart carpark"},
+				{"%reward_amount", "heaps!"},
+				{"%reward_type", "Pants"}, 
+				{"%rule_engage", "Kill em all!"},
+				{"%rule_loot", "don't touch!"}
+			};
+		} 
+		else if (type == "advert") {
+			dictionary bnn_dict = {
+				{"%company_name", "Bob Pizza"}
+			};
+		}
+		return bnn_dict;
+	}
+
+	protected void newBNNAnnouncement(string type, dictionary a) {
+		_log("making a thing now!", 1);
+		notify(m_metagame, "BNN " + type, a);
+	}
+
+    protected string getBNNMissionType() {
+        return "mission";
+    }
+
+    protected string getBNNAdvert() {
+        return "advert";
+    }
+    
+	// --------------------------------------------
+	bool hasEnded() const {
+		// always on
+		return false;
+	}
+
+	// --------------------------------------------
+	bool hasStarted() const {
+		// always on
+		return true;
+	}
+
+	// --------------------------------------------
+	void update(float time) {
+		m_timer -= time;
+		a_timer -= time;
+		if (m_timer <= 0.0) {
+			_log("mission timer expired. BNN announcement incoming", 1);
+			//dictionary miDict = makeBNNDict("mission");
+			dictionary miDict = {
+				{"%activity", "the thing"},
+				{"%character_name", "char name"},
+				{"%company_name", "Bob Pizza"}, 
+				{"%location_pickup", "round the corner"},
+				{"%location_drop", "rah bish binnie"},
+				{"%location", "secret loc"},
+				{"%vicinity", "k-mart carpark"},
+				{"%reward_amount", "heaps!"},
+				{"%reward_type", "Pants"}, 
+				{"%rule_engage", "Kill em all!"},
+				{"%rule_loot", "don't touch!"}
+			};
+			newBNNAnnouncement("mission", miDict);
+			restartTimer("mission");
+		} 
+		if (a_timer <= 0.0) {
+			_log("advert timer expired. BNN announcement incoming", 1);
+			dictionary adDict = makeBNNDict("advert");
+			newBNNAnnouncement("advert", adDict);
+			restartTimer("advert");
+		}
+	}
+	// ----------------------------------------------------
+}
+
+
+/*
+// -------------------------------------------------------
+void notify(const Metagame@ metagame, string key, dictionary@ replacements = dictionary(), string dict = "") {
+	_log(" * notification message: " + key, 1);
+	string command =
+		"<command class='notify' dict='" + dict + "' key='" + key + "'>";
+
+	command += handleReplacements(replacements);
+	command += "</command>";
+
+	metagame.getComms().send(command);
+}
+*/

--- a/scripts/trackers/item_delivery_objective.as
+++ b/scripts/trackers/item_delivery_objective.as
@@ -210,6 +210,13 @@ class ItemDeliveryObjective : Objective {
 		// don't process if not properly started
 		if (!hasStarted()) return;
 
+		// BC Hot Potato item tracker
+		// we only need to know if the hot potato is dropped on the ground. Otherwise, it's still held by the target
+		if ((event.getStringAttribute("item_key") == "hot_potato.projectile") && (event.getStringAttribute("target_container_type_id") == "0")) {
+			string hpPosi = event.getStringAttribute("position");
+			_log("Hot Potato has been dropped on the ground at " + hpPosi, 1);
+			setHotPotPosi(hpPosi); // see helpers.as
+		}
 		// if already delivered, don't care
 		if (m_deliveryDone) return;
 

--- a/weapons/hot_pot_boom.projectile
+++ b/weapons/hot_pot_boom.projectile
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- if the hot potato isn't found in the target's backpack before the timer expires, this projectile detonates at the target's position -->
 <!-- this projectile is not to be used other than its intended purpose (created through call_handler.as) -->
-<projectile class="grenade" name="HOT POT" key="hot_pot_boom.projectile" slot="0" radius="0.15" can_be_disarmed="0">
+<projectile class="grenade" name="HOT POT" key="hot_pot_boom.projectile" slot="0" radius="0.15" can_be_disarmed="0" time_to_live_out_in_the_open="0.0">
     <tag name="grenade" />
 
     <result class="blast" radius="9.0" damage="8.01" push="8" decal="1" character_state="death" />

--- a/weapons/hot_potato.projectile
+++ b/weapons/hot_potato.projectile
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<projectile class="grenade" name="HOT POTATO" key="hot_potato.projectile" slot="0" radius="0.15" can_be_disarmed="0" drop_count_factor_on_death="0.0">
+<projectile class="grenade" name="HOT POTATO" key="hot_potato.projectile" slot="0" radius="0.15" can_be_disarmed="0" drop_count_factor_on_death="0.0" time_to_live_out_in_the_open="10.0">
     <tag name="grenade" />
 
     <result class="blast" radius="9.0" damage="8.01" push="8" decal="1" character_state="death" />


### PR DESCRIPTION
usual non-production-quality code that happens to work reasonably well :-D
Start up a new campaign and watch top-right of screen. Missions currently being announced far too often, solely for testing purposes. Need to implement the advertised missions in a later story. Advert timer on 2~4 minute rotation. It works and doesn't need to spam.

Also some other stuff that appears to have been sitting around waiting for merge for a while. 

Ignore bombing run call. It doesn't do anything and isn't meant to be in there but too lazy to remove at this juncture.